### PR TITLE
Reduce the length of the index key name.

### DIFF
--- a/db/migrate/20220104121238_create_attacked_blocked_ip_addresses.rb
+++ b/db/migrate/20220104121238_create_attacked_blocked_ip_addresses.rb
@@ -1,7 +1,7 @@
 class CreateAttackedBlockedIpAddresses < ActiveRecord::Migration[5.1]
   def change
     create_table :attacked_blocked_ip_addresses do |t|
-      t.string :ip_address, index: { unique: true }
+      t.string :ip_address, index: { unique: true, name: "idx_attacked_blocked_ip_on_ip" }
       t.text :description
       t.timestamps
     end


### PR DESCRIPTION
Reduce the length of the index key name as it was causing issues being migrated in a database.

This is a breaking change to any existing installations.